### PR TITLE
Update configuration.nix

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -28,8 +28,9 @@
     options = "--delete-older-than 7d";
   };
 
-  boot.loader.grub.enable = true;
-  boot.loader.grub.device = "/dev/sda";
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+  boot.loader.efi.efiSysMountPoint = "/boot/efi";
 
   # Enable the OpenSSH service
   services.openssh.enable = true;


### PR DESCRIPTION
This pull request includes a significant change to the boot loader configuration in the `configuration.nix` file. The most important changes involve switching from GRUB to systemd-boot and updating the EFI settings.

Boot loader configuration updates:

* [`configuration.nix`](diffhunk://#diff-7fb0d30826718de8f216d0f0a15452c87445e0bbb745754bf77e1320079f46f9L31-R33): Changed the boot loader from GRUB to systemd-boot by enabling `systemd-boot` and setting EFI-related variables (`canTouchEfiVariables` and `efiSysMountPoint`).